### PR TITLE
Capitalize JWT algorithm used for webhook

### DIFF
--- a/app/models/webhook.js
+++ b/app/models/webhook.js
@@ -25,7 +25,7 @@ const Webhooks = db.table('webhooks', {
       const hookDataHash = sha256(hookDataString)
       const token = jws.sign({
         secret: this.secret,
-        header: {typ: 'JWT', alg: 'hs256'},
+        header: {typ: 'JWT', alg: 'HS256'},
         payload: {
           body: {
             alg: 'sha256',


### PR DESCRIPTION
While the JWT standard doesn't explicitly say that algorithm names must
be capitalized, all of its examples are capitalized (e.g. 'HS256'
instead of 'hs256').  The lower-case name caused a spurious signature
failure for me.
