### PR TITLE
HTTP connection hangs when trying to create a duplicate badge instance

### DIFF
--- a/app/routes/badge-instances.js
+++ b/app/routes/badge-instances.js
@@ -130,6 +130,9 @@ exports = module.exports = function applyBadgeRoutes (server) {
           issuedOn: unixtimeFromDate(instance.issuedOn),
         }
         return Webhooks.getOne({systemId: system.id})
+      }, function(error) {
+        res.send(409, {status: "yuck"});
+        // Do more stuff here!  I don't know Node at all.
       }).then(function (hook) {
         if (!hook)
           return log.info({code: 'WebhookNotFound', system: system}, 'Webhook not found for system')


### PR DESCRIPTION
I'm able to issue badge instances by using `POST /systems/:slug/badges/:slug/instances`.  However, if I try to issue a second badge to the same e-mail address, the server does not behave properly.  It should give me back an HTTP `409 Conflict`, as in the "Duplicate entry" error message in [this other endpoint](https://github.com/mozilla/badgekit-api/blob/master/docs/badges.md).  Instead, it either closes the connection or leaves it hanging, I can't tell.

The pull request here is obviously not a solution, it just points out where the error-handling logic could go.  It does cause the HTTP connection to terminate correctly, so my client library doesn't hang forever waiting for a response.
