### PR TITLE
Fix public link from badge class to issuer

### DIFF
--- a/app/routes/badge-instances.js
+++ b/app/routes/badge-instances.js
@@ -402,7 +402,7 @@ exports = module.exports = function applyBadgeRoutes (server) {
       return util.format('/public/systems/%s/issuers/%s/programs/%s',
                          system.slug, issuer.slug, program.slug)
     if (issuer && issuer.slug)
-      return util.format('/public/systems/%s/issuers',
+      return util.format('/public/systems/%s/issuers/%s',
                          system.slug, issuer.slug)
     if (badge.system && badge.system.slug)
       return util.format('/public/systems/%s', system.slug)


### PR DESCRIPTION
In the case that a badge had a system and an issuer, but not a program, the public APIs were generating an incorrect URL for the issuer: `/public/systems/badgekit/issuers%20k-rad` instead of `/public/systems/badgekit/issuers/k-rad`.  The problem was just a missing piece of the format string.
