### PR TITLE
added env_local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ node_modules
 *.local
 
 config.*
+
+env_local


### PR DESCRIPTION
Given that the  instructions in https://github.com/mozilla/openbadges-badgekit/wiki/BadgeKit-Self-Hosting-Guide#badgekit-api-configuration suggests storing db authentication configuration in badgekit-api/env_local as one of two possibilities, I think env_local should be the .gitignore, unless I misunderstood the instructions.