### PR TITLE
Use valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.22",
   "description": "A badge issuing platform",
   "author": "Mozilla OpenBadges",
-  "license": "MPLv2",
+  "license": "MPL-2.0",
   "main": "app/index.js",
   "scripts": {
     "start": "node app",


### PR DESCRIPTION
`npm install` complains about invalid license identifier.

This PR replaces the identifier with this one:
https://spdx.org/licenses/MPL-2.0.html