### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "jshint app/*"
   },
   "dependencies": {
-    "mysql": "~2.0.0-alpha9",
-    "restify": "~2.8.2",
+    "mysql": "2.16.0",
+    "restify": "4.3.0",
     "habitat": "0.4.1",
     "streamsql": "~0.8.3",
     "validator": "~2.0.0",


### PR DESCRIPTION
The mysql npm module that came with git repo wasn't the latest, thus causing errors when the badgekitapi NodeJS app tried to connect to the local MySQL instance. To solve this, modified package.json to use the latest mysql module version (2.16.0) and then ran 'npm install'. Also, updated restify to 4.3.0, bring up REST API without errors.

Tested by bringing up REST endpoint.